### PR TITLE
Include svgs and icon font in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
   },
   "files": [
     "build/index.js",
-    "build/example.js"
+    "build/example.js",
+    "icon-font",
+    "svg",
+    "svg-min",
+    "svg-sprite"
   ],
   "devDependencies": {
     "babel-plugin-add-module-exports": "0.2.1",


### PR DESCRIPTION
This is convenient for anyone wanting to use the icons via Webpack or other build tool.