### PR TITLE
Include SVG spritemap in NPM package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "license": "GPL-2.0+",
   "files": [
     "build/index.js",
-    "build/example.js"
+    "build/example.js",
+    "svg-sprite/social-logos.svg"
   ],
   "dependencies": {
     "prop-types": "^15.5.7"


### PR DESCRIPTION
Currently, only the `.js` files resulting from the transpilation of SVG data into React sources are included in the NPM package.

This PR modifies `package.json` to include the SVG sprite as well, so that consumers of the NPM package have access to that file too.

In Calypso, this will allow us to transition away from the SVG-in-JS icons to a better approach, making use of the spritemap with SVG external content.